### PR TITLE
Add single file save functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Build directory
 obj/
 
-# Editor binary
-editor
-
 # Prerequisites
 *.d
 
@@ -37,4 +34,14 @@ editor
 .Spotlight-V100
 .Trashes
 ehthumbs.db
-Thumbs.db 
+Thumbs.db
+
+# Exclude editor binary but keep src
+/miv
+
+# Exclude binaries in root
+*.exe
+*.out
+
+# Exclude build directory
+build/ 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -pedantic -std=c99
-TARGET = editor
+TARGET = miv
 SRCDIR = src
 OBJDIR = obj
 DIRS = core input terminal buffer output events

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -1,0 +1,3 @@
+@echo.off
+
+copy miv.exe %windir%\System32\miv.exe

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo cp miv /usr/local/bin/miv

--- a/src/buffer/row.c
+++ b/src/buffer/row.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include "row.h"
-#include "../events/observer.h"
 
 void editor_row_insert_char(editor_row *row, int at, int c) {
     if (at < 0 || at > row->size) at = row->size;
@@ -37,8 +36,6 @@ void editor_insert_char(int c) {
 
     editor_row_insert_char(&Editor.row[Editor.cy], Editor.cx, c);
     Editor.cx++;
-
-    editor_notify(EVENT_INSERT);
 }
 
 void editor_insert_newline(void) {
@@ -53,7 +50,6 @@ void editor_insert_newline(void) {
     }
     Editor.cy++;
     Editor.cx = 0;
-    editor_notify(EVENT_NEWLINE);
 }
 
 void editor_delete_char(void) {
@@ -63,7 +59,6 @@ void editor_delete_char(void) {
     editor_row *row = &Editor.row[Editor.cy];
     if (Editor.cx < row->size) {
         editor_row_delete_char(row, Editor.cx);
-        editor_notify(EVENT_DELETE);
     } else {
         // At end of line, join with next line
         Editor.cx = row->size;
@@ -76,7 +71,6 @@ void editor_delete_char(void) {
         // Remove the next line
         memmove(&Editor.row[Editor.cy + 1], &Editor.row[Editor.cy + 2], sizeof(editor_row) * (Editor.numrows - Editor.cy - 2));
         Editor.numrows--;
-        editor_notify(EVENT_DELETE);
     }
 }
 

--- a/src/buffer/row.h
+++ b/src/buffer/row.h
@@ -2,7 +2,7 @@
 #define ROW_H
 
 #include <stddef.h>
-#include "../init/init.h"
+#include "../editor/editor.h"
 
 void editor_row_insert_char(editor_row *row, int at, int c);
 void editor_row_delete_char(editor_row *row, int at);

--- a/src/editor/editor.c
+++ b/src/editor/editor.c
@@ -1,13 +1,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include "init.h"
+#include <time.h>
+#include "editor.h"
 #include "../events/observer.h"
 #include "../terminal/terminal.h"
 #include "../output/screen.h"
 #include "../input/error.h"
 
 static void init_editor_state(void) {
+    if (!Editor.filename) {
+        Editor.filename = malloc(256);
+        if (!Editor.filename) die("malloc");
+
+        time_t now = time(NULL);
+        struct tm* tm = localtime(&now);
+        snprintf(Editor.filename, 256, 
+                "untitled_%04d%02d%02d.txt",
+                tm->tm_year + 1900,
+                tm->tm_mon + 1,
+                tm->tm_mday);
+    }
+    
     Editor.cx = 0;
     Editor.cy = 0;
     Editor.numrows = 0;

--- a/src/editor/editor.h
+++ b/src/editor/editor.h
@@ -4,32 +4,32 @@
 #include <termios.h>
 #include <stdbool.h>
 
-/*** defines ***/
 #define CTRL_KEY(k) ((k) & 0x1f)
 #define MIV_VERSION "0.0.1"
 #define MAX_CALLBACKS 32
 
-/*** enums ***/
 enum editor_key {
     ARROW_LEFT = 1000,
     ARROW_RIGHT,
     ARROW_UP,
     ARROW_DOWN,
     DEL_KEY,
-    BACKSPACE
+    BACKSPACE,
+    SAVE_KEY,
 };
 
 enum editor_event {
+    EVENT_NULL,
     EVENT_CURSOR_MOVE,
     EVENT_INSERT,
     EVENT_DELETE,
     EVENT_WINDOW_RESIZE,
     EVENT_FILE_OPEN,
     EVENT_NEWLINE,
+    EVENT_SAVE,
     EVENT_COUNT
 };
 
-/*** data structures ***/
 typedef struct editor_row {
     int size;
     char *chars;
@@ -43,7 +43,8 @@ typedef struct editor_observer {
 } editor_observer;
 
 struct editor {
-    int cx, cy;          // Cursor x and y position
+    char *filename;
+    int cx, cy;
     int screenrows;
     int screencols;
     int numrows;

--- a/src/events/observer.c
+++ b/src/events/observer.c
@@ -1,5 +1,5 @@
 #include "observer.h"
-#include "../init/init.h"
+#include "../editor/editor.h"
 
 void editor_register_callback(enum editor_event event, callback_fn callback) {
     if (Editor.num_observers >= MAX_CALLBACKS) return;

--- a/src/events/observer.h
+++ b/src/events/observer.h
@@ -1,7 +1,7 @@
 #ifndef OBSERVER_H
 #define OBSERVER_H
 
-#include "../init/init.h"
+#include "../editor/editor.h"
 
 void editor_register_callback(enum editor_event event, callback_fn callback);
 void editor_notify(enum editor_event event);

--- a/src/input/command.h
+++ b/src/input/command.h
@@ -1,19 +1,19 @@
 #ifndef COMMAND_H
 #define COMMAND_H
 
-#include "../init/init.h"
+#include "../editor/editor.h"
 #include <stdbool.h>
 
 struct editor_command {
     int key;
     void (*execute)(int);
-    bool moves_cursor;
+    enum editor_event event;
     const char* name;
 };
 
 void process_command(const char *command);
 void editor_find(void);
-void editor_save(void);
+void editor_save(int key);
 void editor_quit(void);
 
 extern const struct editor_command EDITOR_COMMANDS[];

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -5,7 +5,7 @@
 #include "keyboard.h"
 #include "command.h"
 #include "error.h"
-#include "../init/init.h"
+#include "../editor/editor.h"
 #include "../events/observer.h"
 
 int editor_read_key(void) {
@@ -111,12 +111,10 @@ void editor_process_keypress(void) {
         cmd = &EDITOR_COMMANDS[NUM_EDITOR_COMMANDS - 1];  // Last command is the default handler
     }
 
-    // Execute the command
     cmd->execute(c);
     
-    // Notify cursor movement if needed
-    if (cmd->moves_cursor) {
-        editor_notify(EVENT_CURSOR_MOVE);
+    if (cmd->event != EVENT_NULL) {
+        editor_notify(cmd->event);
     }
 } 
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,4 @@
-#include "init/init.h"
+#include "editor/editor.h"
 #include "terminal/terminal.h"
 #include "output/screen.h"
 #include "input/keyboard.h"

--- a/src/output/screen.c
+++ b/src/output/screen.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "screen.h"
-#include "../init/init.h"
+#include "../editor/editor.h"
 
 void editor_draw_rows(struct abuf *ab) {
     int y;

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -5,7 +5,7 @@
 #include <termios.h>
 #include <unistd.h>
 #include "terminal.h"
-#include "../init/init.h"
+#include "../editor/editor.h"
 #include "../input/error.h"
 
 void disable_raw_mode(void) {


### PR DESCRIPTION
Handles the case where a single file is created without a filename. Uses default filename, which will likely change to prompt the user for an explicit filename. 